### PR TITLE
Adding Subscriptions to Android

### DIFF
--- a/src/js/index-android.js
+++ b/src/js/index-android.js
@@ -42,30 +42,41 @@ inAppPurchase.getProducts = (productIds) => {
   });
 };
 
-inAppPurchase.buy = (productId) => {
-  return new Promise((resolve, reject) => {
-    if(!inAppPurchase.utils.validString(productId)) {
+var executePaymentOfType = (resolve, reject, productId, type) => {
+    if (!inAppPurchase.utils.validString(productId)) {
       reject(new Error(inAppPurchase.utils.errors[102]));
     } else {
-      nativeCall('buy', [productId]).then((res) => {
+      nativeCall(type, [productId]).then(function (res) {
         resolve({
           signature: res.signature,
           productId: res.productId,
           transactionId: res.purchaseToken,
-          type : res.type,
-          receipt : JSON.stringify({
+          type: res.type,
+          receipt: JSON.stringify({
             orderId: res.orderId,
             packageName: res.packageName,
             productId: res.productId,
             purchaseTime: res.purchaseTime,
             purchaseState: res.purchaseState,
-            purchaseToken: res.purchaseToken,
-          }),
+            purchaseToken: res.purchaseToken
+          })
         });
       }).catch(reject);
     }
+};
+
+inAppPurchase.buy = (productId) => {
+  return new Promise((resolve, reject) => {
+    executePaymentOfType(resolve, reject, productId, 'buy')
   });
 };
+
+inAppPurchase.subscribe = (productId) => {
+  return new Promise((resolve, reject) => {
+    executePaymentOfType(resolve, reject, productId, 'subscribe')
+  });
+};
+
 
 inAppPurchase.consume = (type, receipt, signature) => {
   return new Promise((resolve, reject) => {

--- a/src/js/index-android.js
+++ b/src/js/index-android.js
@@ -46,7 +46,7 @@ var executePaymentOfType = (resolve, reject, productId, type) => {
     if (!inAppPurchase.utils.validString(productId)) {
       reject(new Error(inAppPurchase.utils.errors[102]));
     } else {
-      nativeCall(type, [productId]).then(function (res) {
+      nativeCall(type, [productId]).then((res) => {
         resolve({
           signature: res.signature,
           productId: res.productId,

--- a/src/js/index-ios.js
+++ b/src/js/index-ios.js
@@ -58,6 +58,10 @@ inAppPurchase.buy = (productId) => {
   });
 };
 
+inAppPurchase.subscribe = (productId) => {
+  return inAppPurchase.buy(productId);
+};
+
 /**
  * This function exists so that the iOS plugin API will be compatible with that of Android -
  * where this function is required.

--- a/test/index-android.js
+++ b/test/index-android.js
@@ -210,6 +210,29 @@ describe('Android purchases', () => {
 
   });
 
+  describe('#subscribe()', () => {
+
+    it('should call the Android subscribe() function with the correct args ', async (done) => {
+      try {
+        const productId = 'com.test.prod1';
+        const orderId = '_some_order_id_';
+        const purchaseToken = '_some_purchase_token_';
+        GLOBAL.window.cordova.exec = (success, err, pluginName, name, args) => {
+          assert(typeof success === 'function', 'should define a success callback');
+          assert(typeof err === 'function', 'should define an error callback');
+          assert(pluginName === 'InAppBillingV3', 'invalid Android plugin name');
+          assert(name === 'subscribe', 'invalid function name');
+          assert(args[0] === productId, 'should get productId as args');
+          success({ orderId, purchaseToken });
+        };
+        await inAppPurchase.subscribe(productId);
+        done();
+      } catch (err) {
+        done(err);
+      }
+    });
+
+  });
   describe('#consume()', () => {
 
     it('should call the Android consume() function with the correct args ', async (done) => {

--- a/test/index-ios.js
+++ b/test/index-ios.js
@@ -165,6 +165,22 @@ describe('iOS purchases', () => {
 
   });
 
+  //TODO: Uncomment and add chai-spies. (http://chaijs.com/plugins/chai-spies/)
+  // describe('#subscribe()',() =>{
+  //   it('should call buy method', async(done) =>{
+  //     try{
+  //       //TODO: add mocks here so we can test if subscribe calls buy method
+  //       spy = chai.spy.on(inAppPurchase, 'buy')
+  //       mock.expects(:buy)
+  //       inAppPurchase.subscribe();
+  //       expect(spy).to.have.been.called.exactly(3);
+  //       done();
+  //     } catch (err) {
+  //       done(err);
+  //     }
+  //   });
+  // });
+
   describe('#consume()', () => {
 
     it('should always successfully resolve without doing anything', async (done) => {

--- a/www/index-android.js
+++ b/www/index-android.js
@@ -114,28 +114,38 @@ inAppPurchase.getProducts = function (productIds) {
   });
 };
 
+var executePaymentOfType = function executePaymentOfType(resolve, reject, productId, type) {
+  if (!inAppPurchase.utils.validString(productId)) {
+    reject(new Error(inAppPurchase.utils.errors[102]));
+  } else {
+    nativeCall(type, [productId]).then(function (res) {
+      resolve({
+        signature: res.signature,
+        productId: res.productId,
+        transactionId: res.purchaseToken,
+        type: res.type,
+        receipt: JSON.stringify({
+          orderId: res.orderId,
+          packageName: res.packageName,
+          productId: res.productId,
+          purchaseTime: res.purchaseTime,
+          purchaseState: res.purchaseState,
+          purchaseToken: res.purchaseToken
+        })
+      });
+    }).catch(reject);
+  }
+};
+
 inAppPurchase.buy = function (productId) {
   return new Promise(function (resolve, reject) {
-    if (!inAppPurchase.utils.validString(productId)) {
-      reject(new Error(inAppPurchase.utils.errors[102]));
-    } else {
-      nativeCall('buy', [productId]).then(function (res) {
-        resolve({
-          signature: res.signature,
-          productId: res.productId,
-          transactionId: res.purchaseToken,
-          type: res.type,
-          receipt: JSON.stringify({
-            orderId: res.orderId,
-            packageName: res.packageName,
-            productId: res.productId,
-            purchaseTime: res.purchaseTime,
-            purchaseState: res.purchaseState,
-            purchaseToken: res.purchaseToken
-          })
-        });
-      }).catch(reject);
-    }
+    executePaymentOfType(resolve, reject, productId, 'buy');
+  });
+};
+
+inAppPurchase.subscribe = function (productId) {
+  return new Promise(function (resolve, reject) {
+    executePaymentOfType(resolve, reject, productId, 'subscribe');
   });
 };
 

--- a/www/index-ios.js
+++ b/www/index-ios.js
@@ -92,6 +92,10 @@ inAppPurchase.buy = function (productId) {
   });
 };
 
+inAppPurchase.subscribe = function (productId) {
+  return inAppPurchase.buy(productId);
+};
+
 /**
  * This function exists so that the iOS plugin API will be compatible with that of Android -
  * where this function is required.


### PR DESCRIPTION
Adding the ability to create subscriptions on android. 

```
inAppPurchase.subscribe("my_product_id_for_a_subscription")
```

It works on both android and ios. Since ios does not need any special methods for allowing this, the javascript `.subscribe` method simply wraps the `.buy` method.

I added some tests, but I wasn't able to run the code coverage correctly on my machine, so please verify this before merging.