### PR TITLE
[#23] Adds `errorCode` to Android error object

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/package.json
+++ b/package.json
@@ -45,11 +45,12 @@
     "babel-polyfill": "6.5.0",
     "babel-preset-es2015": "6.5.0",
     "gulp": "3.9.1",
+    "gulp-add-src": "^0.2.0",
     "gulp-babel": "6.1.2",
     "gulp-concat": "2.6.0",
     "gulp-plumber": "1.1.0",
     "gulp-util": "^3.0.7",
-    "vinyl-source-stream": "^1.1.0",
-    "gulp-add-src": "^0.2.0"
+    "mocha": "^2.4.5",
+    "vinyl-source-stream": "^1.1.0"
   }
 }

--- a/src/js/index-android.js
+++ b/src/js/index-android.js
@@ -9,13 +9,19 @@
 
 const inAppPurchase = { utils };
 
+const createIapError = (reject) => {
+  return (err = {}) => {
+    err.errorCode = err.code;
+    delete err.code;
+    return reject(err);
+  };
+};
+
 const nativeCall = (name, args = []) => {
   return new Promise((resolve, reject) => {
     window.cordova.exec((res) => {
       resolve(res);
-    }, (err) => {
-      reject(err);
-    }, 'InAppBillingV3', name, args);
+    }, createIapError(reject), 'InAppBillingV3', name, args);
   });
 };
 

--- a/src/js/index-android.js
+++ b/src/js/index-android.js
@@ -12,7 +12,6 @@ const inAppPurchase = { utils };
 const createIapError = (reject) => {
   return (err = {}) => {
     err.errorCode = err.code;
-    delete err.code;
     return reject(err);
   };
 };

--- a/test/index-android.js
+++ b/test/index-android.js
@@ -3,6 +3,8 @@ import assert from 'assert';
 
 describe('Android purchases', () => {
 
+  const execError = code => (success, err, pluginName, name, args) => err({ code });
+
   before(() => {
     GLOBAL.window = {};
     GLOBAL.window.cordova = {};
@@ -117,6 +119,17 @@ describe('Android purchases', () => {
       done();
     });
 
+    it('should return an errorCode property when there is an error', async (done) => {
+      try {
+        GLOBAL.window.cordova.exec = execError(-1)
+        await inAppPurchase.getProducts(['com.test.prod1']);
+        done(new Error('Call to #getProducts() suceeded but was expected to fail.'));
+      } catch (err) {
+        assert(err.errorCode === -1, 'should create an errorCode property');
+        done();
+      }
+    });
+
   });
 
   describe('#buy()', () => {
@@ -202,6 +215,17 @@ describe('Android purchases', () => {
       }
     });
 
+    it('should return an errorCode property when there is an error', async (done) => {
+      try {
+        GLOBAL.window.cordova.exec = execError(-1);
+        await inAppPurchase.buy('com.test.prod1');
+        done(new Error('Call to #buy() suceeded but was expected to fail.'));
+      } catch (err) {
+        assert(err.errorCode === -1, 'should create an errorCode property');
+        done();
+      }
+    });
+
   });
 
   describe('#subscribe()', () => {
@@ -223,6 +247,17 @@ describe('Android purchases', () => {
         done();
       } catch (err) {
         done(err);
+      }
+    });
+
+    it('should return an errorCode property when there is an error', async (done) => {
+      try {
+        GLOBAL.window.cordova.exec = execError(-1);
+        await inAppPurchase.subscribe('com.test.prod1');
+        done(new Error('Call to #subscribe() suceeded but was expected to fail.'));
+      } catch (err) {
+        assert(err.errorCode === -1, 'should create an errorCode property');
+        done();
       }
     });
 
@@ -249,6 +284,20 @@ describe('Android purchases', () => {
         done();
       } catch (err) {
         done(err);
+      }
+    });
+
+    it('should return an errorCode property when there is an error', async(done) => {
+      try {
+        const receipt = '_some_receipt_';
+        const signature = '_some_signature_';
+        const type = 'inapp';
+        GLOBAL.window.cordova.exec = execError(-1);
+        await inAppPurchase.consume(type, receipt, signature);
+        done(new Error('Call to #consume() suceeded but was expected to fail.'));
+      } catch (err) {
+        assert(err.errorCode === -1, 'should create an errorCode property');
+        done();
       }
     });
 
@@ -319,6 +368,17 @@ describe('Android purchases', () => {
         done();
       } catch (err) {
         done(err);
+      }
+    });
+
+    it('should return an errorCode property when there is an error', async(done) => {
+      try {
+        GLOBAL.window.cordova.exec = execError(-1);
+        await inAppPurchase.restorePurchases();
+        done(new Error('Call to #restorePurchases() suceeded but was expected to fail.'));
+      } catch (err) {
+        assert(err.errorCode === -1, 'should create an errorCode property');
+        done();
       }
     });
 

--- a/www/index-android.js
+++ b/www/index-android.js
@@ -85,7 +85,6 @@ var createIapError = function createIapError(reject) {
     var err = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
 
     err.errorCode = err.code;
-    delete err.code;
     return reject(err);
   };
 };

--- a/www/index-android.js
+++ b/www/index-android.js
@@ -80,15 +80,23 @@ utils.validString = function (val) {
 
 var inAppPurchase = { utils: utils };
 
+var createIapError = function createIapError(reject) {
+  return function () {
+    var err = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
+
+    err.errorCode = err.code;
+    delete err.code;
+    return reject(err);
+  };
+};
+
 var nativeCall = function nativeCall(name) {
   var args = arguments.length <= 1 || arguments[1] === undefined ? [] : arguments[1];
 
   return new Promise(function (resolve, reject) {
     window.cordova.exec(function (res) {
       resolve(res);
-    }, function (err) {
-      reject(err);
-    }, 'InAppBillingV3', name, args);
+    }, createIapError(reject), 'InAppBillingV3', name, args);
   });
 };
 


### PR DESCRIPTION
Previously, the Android error object  used `code` to indicate the error code while iOS
used `errorCode`. This updates Android to use `errorCode` so that consuming
code does not need to branch based on platform.