### PR TITLE
[#26] Maps iOS PaymentCancelled error to USER_CANCELLED

### DIFF
--- a/src/js/index-ios.js
+++ b/src/js/index-ios.js
@@ -9,13 +9,16 @@
 
 const inAppPurchase = { utils };
 
+const createIapError = (reject) => {
+  return (err = {}) => {
+    err.message = err.errorCode === 2 ? 'USER_CANCELLED' : err.message;
+    return reject(err);
+  };
+};
+
 const nativeCall = (name, args = []) => {
   return new Promise((resolve, reject) => {
-    window.cordova.exec((res) => {
-      resolve(res);
-    }, (err) => {
-      reject(err);
-    }, 'PaymentsPlugin', name, args);
+    window.cordova.exec(resolve, createIapError(reject), 'PaymentsPlugin', name, args);
   });
 };
 

--- a/test/index-ios.js
+++ b/test/index-ios.js
@@ -3,6 +3,8 @@ import assert from 'assert';
 
 describe('iOS purchases', () => {
 
+  const execError = errorCode => (success, err, pluginName, name, args) => err({ errorCode });
+
   before(() => {
     GLOBAL.window = {};
     GLOBAL.window.cordova = {};
@@ -163,6 +165,17 @@ describe('iOS purchases', () => {
       }
     });
 
+    it('should return a message of USER_CANCELLED when there is a PaymentCancelled error', async (done) => {
+      try {
+        GLOBAL.window.cordova.exec = execError(2)
+        await inAppPurchase.buy('com.test.prod1');
+        done(new Error('Call to #buy() suceeded but was expected to fail.'));
+      } catch (err) {
+        assert(err.message === 'USER_CANCELLED', 'should report USER_CANCELLED message');
+        done();
+      }
+    });
+
   });
 
   describe('#subscribe()', () => {
@@ -184,6 +197,17 @@ describe('iOS purchases', () => {
         done();
       } catch (err) {
         done(err);
+      }
+    });
+
+    it('should return a message of USER_CANCELLED when there is a PaymentCancelled error', async (done) => {
+      try {
+        GLOBAL.window.cordova.exec = execError(2)
+        await inAppPurchase.subscribe('com.test.prod1');
+        done(new Error('Call to #subscribe() suceeded but was expected to fail.'));
+      } catch (err) {
+        assert(err.message === 'USER_CANCELLED', 'should report USER_CANCELLED message');
+        done();
       }
     });
 

--- a/www/index-ios.js
+++ b/www/index-ios.js
@@ -41,15 +41,20 @@ utils.validString = function (val) {
 
 var inAppPurchase = { utils: utils };
 
+var createIapError = function createIapError(reject) {
+  return function () {
+    var err = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
+
+    err.message = err.errorCode === 2 ? 'USER_CANCELLED' : err.message;
+    return reject(err);
+  };
+};
+
 var nativeCall = function nativeCall(name) {
   var args = arguments.length <= 1 || arguments[1] === undefined ? [] : arguments[1];
 
   return new Promise(function (resolve, reject) {
-    window.cordova.exec(function (res) {
-      resolve(res);
-    }, function (err) {
-      reject(err);
-    }, 'PaymentsPlugin', name, args);
+    window.cordova.exec(resolve, createIapError(reject), 'PaymentsPlugin', name, args);
   });
 };
 


### PR DESCRIPTION
This makes the error message consistent between Android and iOS.
Both will now report USER_CANCELLED when the user exits the IAP flow.