### PR TITLE
null check on intent query for InAppBillingService.

### DIFF
--- a/src/android/IabHelper.java
+++ b/src/android/IabHelper.java
@@ -273,7 +273,9 @@ public class IabHelper {
 
         Intent serviceIntent = new Intent("com.android.vending.billing.InAppBillingService.BIND");
         serviceIntent.setPackage("com.android.vending");
-        if (!mContext.getPackageManager().queryIntentServices(serviceIntent, 0).isEmpty()) {
+
+        List<ResolveInfo> matchingServices = mContext.getPackageManager().queryIntentServices(serviceIntent, 0);
+        if ( matchingServices != null && !matchingServices.isEmpty() ) {
             // service available to handle that Intent
             mContext.bindService(serviceIntent, mServiceConn, Context.BIND_AUTO_CREATE);
         }


### PR DESCRIPTION
Fixes NullPointerException in IabHelperIabHelper on emulator environment where in app billing service is not available.  Stack trace of error below from logcat:

```
D/google.payments(18242): executing on android
E/PluginManager(18242): Uncaught exception from plugin
E/PluginManager(18242): java.lang.NullPointerException: Attempt to invoke interface method 'boolean java.util.List.isEmpty()' on a null object reference
E/PluginManager(18242): 	at com.alexdisler.inapppurchases.IabHelper.startSetup(IabHelper.java:276)
E/PluginManager(18242): 	at com.alexdisler.inapppurchases.InAppBillingV3.init(InAppBillingV3.java:184)
E/PluginManager(18242): 	at com.alexdisler.inapppurchases.InAppBillingV3.execute(InAppBillingV3.java:162)
E/PluginManager(18242): 	at org.apache.cordova.CordovaPlugin.execute(CordovaPlugin.java:98)
E/PluginManager(18242): 	at org.apache.cordova.PluginManager.exec(PluginManager.java:133)
E/PluginManager(18242): 	at org.apache.cordova.CordovaBridge.jsExec(CordovaBridge.java:59)
E/PluginManager(18242): 	at org.apache.cordova.engine.SystemExposedJsApi.exec(SystemExposedJsApi.java:41)
E/PluginManager(18242): 	at com.android.org.chromium.base.SystemMessageHandler.nativeDoRunLoopOnce(Native Method)
E/PluginManager(18242): 	at com.android.org.chromium.base.SystemMessageHandler.handleMessage(SystemMessageHandler.java:28)
E/PluginManager(18242): 	at android.os.Handler.dispatchMessage(Handler.java:102)
E/PluginManager(18242): 	at android.os.Looper.loop(Looper.java:135)
E/PluginManager(18242): 	at android.os.HandlerThread.run(HandlerThread.java:61)
```