### PR TITLE
Android getProducts calls getSkuDetails chunked

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -24,3 +24,20 @@ utils.validArrayOfStrings = (val) => {
 utils.validString = (val) => {
   return (val && val.length && typeof val === 'string');
 };
+
+utils.chunk = (array, size) => {
+  if (!Array.isArray(array)) {
+    throw new Error('Invalid array');
+  }
+
+  if (typeof size !== 'number' || size < 1) {
+    throw new Error('Invalid size');
+  }
+
+  const times = Math.ceil(array.length / size);
+  return Array
+    .apply(null, Array(times))
+    .reduce((result, val, i) => {
+      return result.concat([array.slice(i * size, (i + 1) * size)]);
+    }, []);
+};

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,40 @@
+import { utils } from '../www/index-ios';
+import assert from 'assert';
+
+describe('utils', () => {
+  describe('#chunk', () => {
+    it('should chunk a given array', () => {
+      const chunks = utils.chunk(['1', '2', '3', '4', '5'], 2);
+      assert.deepEqual(chunks, [['1', '2'], ['3', '4'], ['5']]);
+    });
+
+    it('should return on chunk when the size is bigger than the array size', () => {
+      const chunks = utils.chunk(['1', '2', '3', '4', '5'], 42);
+      assert.deepEqual(chunks, [['1', '2', '3', '4', '5']]);
+    });
+
+    it('should throw an error on size smaller 1', () => {
+      assert.throws(() => {
+        utils.chunk(['1', '2', '3', '4', '5'], 0);
+      }, (err) => {
+        return err.message === 'Invalid size';
+      }, 'unexpected error');
+    });
+
+    it('should throw an error on non numeric size', () => {
+      assert.throws(() => {
+        utils.chunk(['1', '2', '3', '4', '5'], 'not a number');
+      }, (err) => {
+        return err.message === 'Invalid size';
+      }, 'unexpected error');
+    });
+
+    it('should throw an error when on a non array type', () => {
+      assert.throws(() => {
+        utils.chunk(null, 2);
+      }, (err) => {
+        return err.message === 'Invalid array';
+      }, 'unexpected error');
+    });
+  });
+});

--- a/www/index-ios.js
+++ b/www/index-ios.js
@@ -28,6 +28,21 @@ utils.validArrayOfStrings = function (val) {
 utils.validString = function (val) {
   return val && val.length && typeof val === 'string';
 };
+
+utils.chunk = function (array, size) {
+  if (!Array.isArray(array)) {
+    throw new Error('Invalid array');
+  }
+
+  if (typeof size !== 'number' || size < 1) {
+    throw new Error('Invalid size');
+  }
+
+  var times = Math.ceil(array.length / size);
+  return Array.apply(null, Array(times)).reduce(function (result, val, i) {
+    return result.concat([array.slice(i * size, (i + 1) * size)]);
+  }, []);
+};
 'use strict';
 
 /*!


### PR DESCRIPTION
This is an alternative pull request for #57 that only changes the way the `getSkuDetails` is called. Instead of modifying native code I added a chunking to the call, so only 19 `productIds` at a time a given to the `getSkuDetails` method. This seems the current solution when working with standard android API. The value 19 is chosen cause I also encountered errors when choosing 20 as chunking value.

I also added unit tests and everything is compatible with the old code.

