### PR TITLE
Support developer payload

### DIFF
--- a/src/android/InAppBillingV3.java
+++ b/src/android/InAppBillingV3.java
@@ -198,8 +198,12 @@ public class InAppBillingV3 extends CordovaPlugin {
 
   protected boolean runPayment(final JSONArray args, final CallbackContext callbackContext, boolean subscribe) {
     final String sku;
+    String developerPayload = "";
     try {
       sku = args.getString(0);
+      if (args.length > 1) {
+        developerPayload = args.getString(1);
+      }
     } catch (JSONException e) {
       callbackContext.error(makeError("Invalid SKU", INVALID_ARGUMENTS));
       return false;
@@ -211,7 +215,6 @@ public class InAppBillingV3 extends CordovaPlugin {
     final Activity cordovaActivity = this.cordova.getActivity();
     int newOrder = orderSerial.getAndIncrement();
     this.cordova.setActivityResultCallback(this);
-
     IabHelper.OnIabPurchaseFinishedListener oipfl = new IabHelper.OnIabPurchaseFinishedListener() {
       public void onIabPurchaseFinished(IabResult result, Purchase purchase) {
         if (result.isFailure()) {
@@ -247,9 +250,9 @@ public class InAppBillingV3 extends CordovaPlugin {
       }
     };
     if(subscribe){
-      iabHelper.launchSubscriptionPurchaseFlow(cordovaActivity, sku, newOrder, oipfl, "");
+      iabHelper.launchSubscriptionPurchaseFlow(cordovaActivity, sku, newOrder, oipfl, developerPayload);
     } else {
-      iabHelper.launchPurchaseFlow(cordovaActivity, sku, newOrder, oipfl, "");
+      iabHelper.launchPurchaseFlow(cordovaActivity, sku, newOrder, oipfl, developerPayload);
     }
     return true;
   }

--- a/src/js/index-android.js
+++ b/src/js/index-android.js
@@ -56,12 +56,13 @@ inAppPurchase.getProducts = (productIds) => {
   });
 };
 
-const executePaymentOfType = (type, productId) => {
+const executePaymentOfType = (type, productId, developerPayload) => {
+  developerPayload = developerPayload || "";
   return new Promise((resolve, reject) => {
-    if (!inAppPurchase.utils.validString(productId)) {
+    if (!inAppPurchase.utils.validString(productId, developerPayload)) {
       reject(new Error(inAppPurchase.utils.errors[102]));
     } else {
-      nativeCall(type, [productId]).then((res) => {
+      nativeCall(type, [productId, developerPayload]).then((res) => {
         resolve({
           signature: res.signature,
           productId: res.productId,
@@ -75,12 +76,12 @@ const executePaymentOfType = (type, productId) => {
   });
 };
 
-inAppPurchase.buy = (productId) => {
-  return executePaymentOfType('buy', productId);
+inAppPurchase.buy = (productId, developerPayload) => {
+  return executePaymentOfType('buy', productId, developerPayload);
 };
 
-inAppPurchase.subscribe = (productId) => {
-  return executePaymentOfType('subscribe', productId);
+inAppPurchase.subscribe = (productId, developerPayload) => {
+  return executePaymentOfType('subscribe', productId, developerPayload);
 };
 
 inAppPurchase.consume = (type, receipt, signature) => {


### PR DESCRIPTION
Google Play IAP v3 allows a developer payload string to be set when making a purchase. This string is then available when the purchase or subscription is returned through the API. This pull request adds support for this to the plugin.

https://developer.android.com/google/play/billing/billing_best_practices.html#payload