### PR TITLE
Android restorePurchase state changed to purchaseState

### DIFF
--- a/www/index-android.js
+++ b/www/index-android.js
@@ -196,7 +196,7 @@ inAppPurchase.restorePurchases = function () {
       arr = purchases.map(function (val) {
         return {
           productId: val.productId,
-          state: val.state,
+          state: val.purchaseState,
           transactionId: val.orderId,
           date: val.date,
           type: val.type,


### PR DESCRIPTION
index-android.js   line 199
changed val.state to val.purchaseState to match the returned values in native code
this way purchase.state is no longer undefined on Android