### PR TITLE
Fix front page example typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ On ***iOS*** there is no need to "consume" a product. However, in order to make 
 ___Example:___
 
 ```js
-// fist buy the product...
+// first buy the product...
 inAppPurchase
   .buy('com.yourapp.consumable_prod1')
   .then(function (data) {


### PR DESCRIPTION
One of the front page examples has "fist" instead of "first"