### PR TITLE
Price as double support

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ If successful, the promise resolves to an array of objects. Each object has the 
 - ```title``` - short localized title
 - ```description``` - long localized description
 - ```price``` - localized price
+- ```priceAsDecimal``` - price as a decimal
 
 ___Example:___
 
@@ -68,7 +69,7 @@ inAppPurchase
   .then(function (products) {
     console.log(products);
     /*
-       [{ productId: 'com.yourapp.prod1', 'title': '...', description: '...', price: '...' }, ...]
+       [{ productId: 'com.yourapp.prod1', 'title': '...', description: '...', price: '...', priceAsDecimal: '...' }, ...]
     */
   })
   .catch(function (err) {

--- a/src/android/InAppBillingV3.java
+++ b/src/android/InAppBillingV3.java
@@ -336,6 +336,7 @@ public class InAppBillingV3 extends CordovaPlugin {
               detailsJson.put("productId", skuDetails.getSku());
               detailsJson.put("title", skuDetails.getTitle());
               detailsJson.put("description", skuDetails.getDescription());
+              detailsJson.put("priceAsDecimal", skuDetails.getPriceAsDecimal());
               detailsJson.put("price", skuDetails.getPrice());
               detailsJson.put("type", skuDetails.getType());
               response.put(detailsJson);

--- a/src/android/SkuDetails.java
+++ b/src/android/SkuDetails.java
@@ -25,6 +25,7 @@ public class SkuDetails {
     String mItemType;
     String mSku;
     String mType;
+    Double mPriceAsDecimal;
     String mPrice;
     String mTitle;
     String mDescription;
@@ -41,6 +42,7 @@ public class SkuDetails {
         mSku = o.optString("productId");
         mType = o.optString("type");
         mPrice = o.optString("price");
+        mPriceAsDecimal = Double.parseDouble(o.optString("price_amount_micros"))/Double.valueOf(1000000);
         mTitle = o.optString("title");
         mDescription = o.optString("description");
     }
@@ -48,6 +50,7 @@ public class SkuDetails {
     public String getSku() { return mSku; }
     public String getType() { return mType; }
     public String getPrice() { return mPrice; }
+    public Double getPriceAsDecimal() { return mPriceAsDecimal; }
     public String getTitle() { return mTitle; }
     public String getDescription() { return mDescription; }
 

--- a/src/ios/PaymentsPlugin.m
+++ b/src/ios/PaymentsPlugin.m
@@ -37,6 +37,7 @@
                                  @"productId": NILABLE(product.productIdentifier),
                                  @"title": NILABLE(product.localizedTitle),
                                  @"description": NILABLE(product.localizedDescription),
+                                 @"priceAsDecimal": NILABLE(product.price),
                                  @"price": NILABLE([RMStore localizedPriceOfProduct:product]),
                               }];
     }

--- a/src/js/index-android.js
+++ b/src/js/index-android.js
@@ -44,10 +44,11 @@ inAppPurchase.getProducts = (productIds) => {
       .then((items) => {
         const arr = items.map((val) => {
           return {
-            productId   : val.productId,
-            title       : val.title,
-            description : val.description,
-            price       : val.price,
+            productId      : val.productId,
+            title          : val.title,
+            description    : val.description,
+            price          : val.price,
+            priceAsDecimal : val.priceAsDecimal,
           };
         });
         resolve(arr);

--- a/src/js/index-ios.js
+++ b/src/js/index-ios.js
@@ -30,10 +30,11 @@ inAppPurchase.getProducts = (productIds) => {
         } else {
           const arr = res.products.map((val) => {
             return {
-              productId   : val.productId,
-              title       : val.title,
-              description : val.description,
-              price       : val.price,
+              productId      : val.productId,
+              title          : val.title,
+              description    : val.description,
+              priceAsDecimal : val.priceAsDecimal,
+              price          : val.price,
             };
           });
           resolve(arr);

--- a/test/index-android.js
+++ b/test/index-android.js
@@ -88,8 +88,8 @@ describe('Android purchases', () => {
     it('should return an array of objects', async (done) => {
       try {
         const products = [
-          { productId: 'com.test.prod1', title: 'prod1 title', description: 'prod1 description', price: '$0.99' },
-          { productId: 'com.test.prod2', title: 'prod2 title', description: 'prod2 description', price: '$1.99' },
+          { productId: 'com.test.prod1', title: 'prod1 title', description: 'prod1 description', price: '$0.99', priceAsDecimal: 0.99 },
+          { productId: 'com.test.prod2', title: 'prod2 title', description: 'prod2 description', price: '$1.99', priceAsDecimal: 1.99 },
         ];
         const productIds = products.map(i => i.productId );
         GLOBAL.window.cordova.exec = (success, err, pluginName, name) => {

--- a/test/index-ios.js
+++ b/test/index-ios.js
@@ -33,8 +33,8 @@ describe('iOS purchases', () => {
     it('should return an array of objects', async (done) => {
       try {
         const products = [
-          { productId: 'com.test.prod1', title: 'prod1 title', description: 'prod1 description', price: '$0.99' },
-          { productId: 'com.test.prod2', title: 'prod2 title', description: 'prod2 description', price: '$1.99' },
+          { productId: 'com.test.prod1', title: 'prod1 title', description: 'prod1 description', price: '$0.99', priceAsDecimal: 0.99 },
+          { productId: 'com.test.prod2', title: 'prod2 title', description: 'prod2 description', price: '$1.99', priceAsDecimal: 1.99 },
         ];
         const productIds = products.map(i => i.productId );
         GLOBAL.window.cordova.exec = (success) => {

--- a/www/index-android.js
+++ b/www/index-android.js
@@ -137,7 +137,8 @@ inAppPurchase.getProducts = function (productIds) {
             productId: val.productId,
             title: val.title,
             description: val.description,
-            price: val.price
+            price: val.price,
+            priceAsDecimal: val.priceAsDecimal
           };
         });
         resolve(arr);

--- a/www/index-ios.js
+++ b/www/index-ios.js
@@ -82,6 +82,7 @@ inAppPurchase.getProducts = function (productIds) {
               productId: val.productId,
               title: val.title,
               description: val.description,
+              priceAsDecimal: val.priceAsDecimal,
               price: val.price
             };
           });


### PR DESCRIPTION
This PR adds the price as a Double value (we wanted to do our own formatting, without having to parse the preformatted price)

For iOS it uses the standard price returned by the API.
For Android it uses the `price_amount_micros` but divides it by 1'000'000 [Documentation](https://developer.android.com/google/play/billing/billing_reference.html#billing-interface)

