### PR TITLE
Added browser platform support

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -10,6 +10,7 @@ const indexAndroid = 'index-android.js';
 const polyfillsAndroid = 'polyfills-android.js';
 const indexIos = 'index-ios.js';
 const utils = 'utils.js';
+const indexBrowser = 'index-browser.js';
 
 const build = () => {
   gulp
@@ -24,6 +25,13 @@ const build = () => {
     .pipe(babel())
     .pipe(addsrc.prepend(src + polyfillsAndroid))
     .pipe(concat(indexAndroid))
+    .pipe(gulp.dest(dist));
+  gulp
+    .src([ src + utils, src + indexBrowser ])
+    .pipe(plumber())
+    .pipe(babel())
+    .pipe(addsrc.prepend(src + polyfillsAndroid))
+    .pipe(concat(indexBrowser))
     .pipe(gulp.dest(dist));
 };
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -63,4 +63,10 @@
     <source-file src="src/android/billing/IInAppBillingService.aidl" target-dir="src/com/android/vending/billing" />
   </platform>
 
+  <platform name="browser">
+    <js-module src="www/index-browser.js" name="InAppPuchaseBrowser">
+      <clobbers target="inAppPurchase" />
+    </js-module>
+  </platform>
+
 </plugin>

--- a/src/js/index-browser.js
+++ b/src/js/index-browser.js
@@ -1,0 +1,36 @@
+/*!
+ *
+ * Author: Neil Rackett (mesmotronic.com)
+ * github.com/alexdisler/cordova-plugin-inapppurchase
+ *
+ * Licensed under the MIT license. Please see README for more information.
+ *
+ */
+
+const inAppPurchase = { utils };
+
+inAppPurchase.getProducts = (productIds) => {
+  return Promise.reject(new Error(inAppPurchase.utils.errors[106]));
+};
+
+inAppPurchase.buy = (productId) => {
+  return Promise.reject(new Error(inAppPurchase.utils.errors[106]));
+};
+
+inAppPurchase.subscribe = (productId) => {
+  return Promise.reject(new Error(inAppPurchase.utils.errors[106]));
+};
+
+inAppPurchase.consume = (type, receipt, signature) => {
+  return Promise.reject(new Error(inAppPurchase.utils.errors[106]));
+};
+
+inAppPurchase.restorePurchases = () => {
+  return Promise.reject(new Error(inAppPurchase.utils.errors[106]));
+};
+
+inAppPurchase.getReceipt = () => {
+  return Promise.reject(new Error(inAppPurchase.utils.errors[106]));
+};
+
+module.exports = inAppPurchase;

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -15,6 +15,7 @@ utils.errors = {
   103: 'invalid argument - product type must be a string',
   104: 'invalid argument - receipt must be a string of a json',
   105: 'invalid argument - signature must be a string',
+  106: 'platform not supported',
 };
 
 utils.validArrayOfStrings = (val) => {

--- a/www/index-browser.js
+++ b/www/index-browser.js
@@ -82,11 +82,11 @@ utils.chunk = function (array, size) {
     return result.concat([array.slice(i * size, (i + 1) * size)]);
   }, []);
 };
-'use strict';
+"use strict";
 
 /*!
  *
- * Author: Alex Disler (alexdisler.com)
+ * Author: Neil Rackett (mesmotronic.com)
  * github.com/alexdisler/cordova-plugin-inapppurchase
  *
  * Licensed under the MIT license. Please see README for more information.
@@ -95,126 +95,28 @@ utils.chunk = function (array, size) {
 
 var inAppPurchase = { utils: utils };
 
-var createIapError = function createIapError(reject) {
-  return function () {
-    var err = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
-
-    err.errorCode = err.code;
-    return reject(err);
-  };
-};
-
-var nativeCall = function nativeCall(name) {
-  var args = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : [];
-
-  return new Promise(function (resolve, reject) {
-    window.cordova.exec(function (res) {
-      resolve(res);
-    }, createIapError(reject), 'InAppBillingV3', name, args);
-  });
-};
-
-var chunkedGetSkuDetails = function chunkedGetSkuDetails(productIds) {
-  // We need to chunk the getSkuDetails call cause it is only allowed to provide a maximum of 20 items per call
-  return utils.chunk(productIds, 19).reduce(function (promise, productIds) {
-    return promise.then(function (result) {
-      return nativeCall('getSkuDetails', productIds).then(function (items) {
-        return result.concat(items);
-      });
-    });
-  }, Promise.resolve([]));
-};
-
 inAppPurchase.getProducts = function (productIds) {
-  return new Promise(function (resolve, reject) {
-    if (!inAppPurchase.utils.validArrayOfStrings(productIds)) {
-      reject(new Error(inAppPurchase.utils.errors[101]));
-    } else {
-      nativeCall('init', []).then(function () {
-        return chunkedGetSkuDetails(productIds);
-      }).then(function (items) {
-        var arr = items.map(function (val) {
-          return {
-            productId: val.productId,
-            title: val.title,
-            description: val.description,
-            price: val.price,
-            currency: val.currency,
-            priceAsDecimal: val.priceAsDecimal
-          };
-        });
-        resolve(arr);
-      }).catch(reject);
-    }
-  });
-};
-
-var executePaymentOfType = function executePaymentOfType(type, productId) {
-  return new Promise(function (resolve, reject) {
-    if (!inAppPurchase.utils.validString(productId)) {
-      reject(new Error(inAppPurchase.utils.errors[102]));
-    } else {
-      nativeCall(type, [productId]).then(function (res) {
-        resolve({
-          signature: res.signature,
-          productId: res.productId,
-          transactionId: res.purchaseToken,
-          type: res.type,
-          productType: res.type,
-          receipt: res.receipt
-        });
-      }).catch(reject);
-    }
-  });
+  return Promise.reject(new Error(inAppPurchase.utils.errors[106]));
 };
 
 inAppPurchase.buy = function (productId) {
-  return executePaymentOfType('buy', productId);
+  return Promise.reject(new Error(inAppPurchase.utils.errors[106]));
 };
 
 inAppPurchase.subscribe = function (productId) {
-  return executePaymentOfType('subscribe', productId);
+  return Promise.reject(new Error(inAppPurchase.utils.errors[106]));
 };
 
 inAppPurchase.consume = function (type, receipt, signature) {
-  return new Promise(function (resolve, reject) {
-    if (!inAppPurchase.utils.validString(type)) {
-      reject(new Error(inAppPurchase.utils.errors[103]));
-    } else if (!inAppPurchase.utils.validString(receipt)) {
-      reject(new Error(inAppPurchase.utils.errors[104]));
-    } else if (!inAppPurchase.utils.validString(signature)) {
-      reject(new Error(inAppPurchase.utils.errors[105]));
-    } else {
-      nativeCall('consumePurchase', [type, receipt, signature]).then(resolve).catch(reject);
-    }
-  });
+  return Promise.reject(new Error(inAppPurchase.utils.errors[106]));
 };
 
 inAppPurchase.restorePurchases = function () {
-  return nativeCall('init', []).then(function () {
-    return nativeCall('restorePurchases', []);
-  }).then(function (purchases) {
-    var arr = [];
-    if (purchases) {
-      arr = purchases.map(function (val) {
-        return {
-          productId: val.productId,
-          state: val.state,
-          transactionId: val.orderId,
-          date: val.date,
-          type: val.type,
-          productType: val.type,
-          signature: val.signature,
-          receipt: val.receipt
-        };
-      });
-    }
-    return Promise.resolve(arr);
-  });
+  return Promise.reject(new Error(inAppPurchase.utils.errors[106]));
 };
 
 inAppPurchase.getReceipt = function () {
-  return Promise.resolve('');
+  return Promise.reject(new Error(inAppPurchase.utils.errors[106]));
 };
 
 module.exports = inAppPurchase;

--- a/www/index-ios.js
+++ b/www/index-ios.js
@@ -16,7 +16,8 @@ utils.errors = {
   102: 'invalid argument - productId must be a string',
   103: 'invalid argument - product type must be a string',
   104: 'invalid argument - receipt must be a string of a json',
-  105: 'invalid argument - signature must be a string'
+  105: 'invalid argument - signature must be a string',
+  106: 'platform not supported'
 };
 
 utils.validArrayOfStrings = function (val) {
@@ -82,9 +83,9 @@ inAppPurchase.getProducts = function (productIds) {
               productId: val.productId,
               title: val.title,
               description: val.description,
-              price: val.price,
-              currency: val.currency,
               priceAsDecimal: val.priceAsDecimal,
+              price: val.price,
+              currency: val.currency
             };
           });
           resolve(arr);


### PR DESCRIPTION
This update implements the plugin's API methods for _browser_ platform, all of which are hard coded to return a rejected `Promise`.

This means that no code changes or workarounds are required to test apps using this plugin in a browser, no more `Uncaught ReferenceError: inAppPurchase is not defined` errors being displayed, and a more graceful workflow for developers targeting the browser platform.